### PR TITLE
Fix for unavailable mathematics package version

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -5,7 +5,7 @@
     "com.unity.cinemachine": "2.1.13",
     "com.unity.collab-proxy": "1.2.15",
     "com.unity.entities": "0.0.12-preview.24",
-    "com.unity.mathematics": "0.0.12-preview.21",
+    "com.unity.mathematics": "0.0.12-preview.20",
     "com.unity.package-manager-ui": "2.0.3",
     "com.unity.postprocessing": "2.1.2",
     "com.unity.purchasing": "2.0.3",


### PR DESCRIPTION
Changed mathematics package version from 0.0.12-preview.21 to 0.0.12-preview.20 to fix fatal errors on first project import with Unity Editor 2018.3.8f1